### PR TITLE
Remove extra '

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,4 @@
 export API_KEY="get your key at https://api.data.gov/signup"
 export CDE_API="https://api.usa.gov/crime/fbi/ucr"
 export PORT=6005
-export THREAT_KEYWORDS='["threat", "words", "here"]''
+export THREAT_KEYWORDS='["threat", "words", "here"]'


### PR DESCRIPTION
Causes syntax errors when trying to copy env.sample into own .env file.